### PR TITLE
parser: fix a bug in parsing raw-data tag/value pairs

### DIFF
--- a/simplefix/parser.py
+++ b/simplefix/parser.py
@@ -144,6 +144,7 @@ class FixParser(object):
                 point += 1
 
                 tag = int(tag_string)
+                in_tag = False
                 if tag in self.raw_data_tags:
                     if raw_len > len(self.buf) - point:
                         break
@@ -155,7 +156,6 @@ class FixParser(object):
                     start = point
 
                 else:
-                    in_tag = False
                     start = point
 
             elif self.buf[point] == SOH_BYTE:


### PR DESCRIPTION
the in_tag field is not reset to False in the case of a raw_data_tag,
causing the next field in the buffer to be parsed incorrectly