### PR TITLE
Fixes #44, README bad link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Typically, a FIX implementation exists as a FIX Engine: a standalone
 service that acts as a gateway for other applications (matching
 engines, trading algos, etc) and implements the FIX protocol.  The
 most popular Open Source FIX engine is probably one of the versions of
-`QuickFIX <http://www.quickfixengine.org>`_.
+`QuickFIX <https://github.com/quickfix/quickfix>`_.
 
 This package provides a *simple* implementation of the FIX
 application-layer protocol.  It does no socket handling, and does not


### PR DESCRIPTION
QuickFIX appears to have lost their quickfixengine.org domain name, so switch to refer to their GitHub homepage for the C++ engine.  Not the best link, but it'll have to so.