### PR TITLE
Fixes #64, error parsing raw data ending on a packet boundary

### DIFF
--- a/simplefix/errors.py
+++ b/simplefix/errors.py
@@ -41,6 +41,8 @@ class TagNotNumberError(ParsingError, ValueError):
 class RawLengthNotNumberError(ParsingError, ValueError):
     """Raw length value could not be converted to integer."""
 
+class RawDataNotFollowedByFieldSeparator(ParsingError):
+    """Raw data field isn't followed by SOH field separator."""
 
 class FieldOrderError(ParsingError):
     """Field not found where required by standard."""

--- a/simplefix/errors.py
+++ b/simplefix/errors.py
@@ -41,8 +41,10 @@ class TagNotNumberError(ParsingError, ValueError):
 class RawLengthNotNumberError(ParsingError, ValueError):
     """Raw length value could not be converted to integer."""
 
+
 class RawDataNotFollowedByFieldSeparator(ParsingError):
     """Raw data field isn't followed by SOH field separator."""
+
 
 class FieldOrderError(ParsingError):
     """Field not found where required by standard."""

--- a/simplefix/parser.py
+++ b/simplefix/parser.py
@@ -299,11 +299,16 @@ class FixParser:
                         raise errors.TagNotNumberError(*e.args)
 
                     if tag in self.raw_data_tags and self.raw_len > 0:
-                        # Try to extract the data value.
-                        if self.raw_len > len(self.buf) - point:
-                            # The buffer doesn't yet contain all the raw data,
-                            # so wait for more to be added.
+                        # Try to extract the data value (and its SOH,
+                        # although that's then ignored)
+                        if self.raw_len + 1 > len(self.buf) - point:
+                            # The buffer doesn't yet contain all the raw data
+                            # plus the following SOH, so wait for more to be added.
                             break
+
+                        # Check for SOH after raw data.
+                        if self.buf[point + self.raw_len] != SOH_BYTE:
+                            raise errors.RawDataNotFollowedByFieldSeparator(tag_string)
 
                         # We've got enough buffer to extract the raw data value.
                         value = self.buf[point:point + self.raw_len]

--- a/simplefix/parser.py
+++ b/simplefix/parser.py
@@ -262,7 +262,7 @@ class FixParser:
         """Return a reference to the internal buffer."""
         return self.buf
 
-    def get_message(self):
+    def get_message(self):  # skipcq: PY-R1000
         """Process the accumulated buffer and return the first message.
 
         If the buffer starts with FIX fields other than BeginString

--- a/simplefix/parser.py
+++ b/simplefix/parser.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 ########################################################################
 # SimpleFIX
-# Copyright (C) 2016-2023, David Arnold.
+# Copyright (C) 2016-2026, David Arnold.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -553,6 +553,36 @@ class ParserTests(unittest.TestCase):
         else:
             self.fail("These keywords together should fail validation.")
 
+    def test_raw_data_ending_on_packet_boundary(self):
+        """Check parsing when raw data field ends on a packet boundary."""
+
+        b1 = b"8=FIX.4.2" + SOH_STR + \
+             b"9=169" + SOH_STR + \
+             b"35=A" + SOH_STR + \
+             b"52=20171213-01:41:08.063" + SOH_STR + \
+             b"49=HelloWorld" + SOH_STR + \
+             b"56=1234" + SOH_STR + \
+             b"34=1" + SOH_STR + \
+             b"95=6" + SOH_STR + \
+             b"96=ABC=DE"
+
+        # Packet boundary between end of data and SOH, as in
+        # https://github.com/da4089/simplefix/issues/64
+
+        b2 = SOH_STR + \
+             b"98=0" + SOH_STR + \
+             b"108=30" + SOH_STR + \
+             b"10=166" + SOH_STR
+
+        parser = FixParser()
+        parser.append_buffer(b1)
+        msg = parser.get_message()
+        self.assertIsNone(msg)
+
+        parser.append_buffer(b2)
+        msg = parser.get_message()
+        self.assertIsNotNone(msg)
+
 
 # b"2018-05-06 12:34:56.789 RECV "
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 ########################################################################
 # SimpleFIX
-# Copyright (C) 2016-2023, David Arnold.
+# Copyright (C) 2016-2026, David Arnold.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,6 @@
 #
 ########################################################################
 
-import sys
 import unittest
 
 from simplefix import FixMessage, FixParser, SOH_STR, errors
@@ -43,6 +42,7 @@ def test_not_none(_, other):  # skipcq: PYL-R1719
 
 class ParserTests(unittest.TestCase):
     """Tests for FIX tag-value parser."""
+
     def setUp(self):
         """Initialize the test suite."""
         if not hasattr(self, "assertIsNotNone"):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -555,7 +555,6 @@ class ParserTests(unittest.TestCase):
 
     def test_raw_data_ending_on_packet_boundary(self):
         """Check parsing when raw data field ends on a packet boundary."""
-
         b1 = b"8=FIX.4.2" + SOH_STR + \
              b"9=169" + SOH_STR + \
              b"35=A" + SOH_STR + \

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -29,27 +29,22 @@ import unittest
 from simplefix import FixMessage, FixParser, SOH_STR, errors
 
 
-def make_str(s):
-    if sys.version_info.major == 2:
-        return bytes(s)
-
-    return bytes(s, 'ASCII')
-
-
 # Python 2.6's unittest.TestCase doesn't have assertIsNone()
 def test_none(_, other):  # skipcq: PYL-R1719
+    """Check for None."""
     return other is None
 
 
 # Python 2.6's unittest.TestCase doesn't have assertIsNotNone()
 def test_not_none(_, other):  # skipcq: PYL-R1719
+    """Check is not None."""
     return other is not None
 
 
 class ParserTests(unittest.TestCase):
-
-
+    """Tests for FIX tag-value parser."""
     def setUp(self):
+        """Initialize the test suite."""
         if not hasattr(self, "assertIsNotNone"):
             ParserTests.assertIsNotNone = test_not_none
         if not hasattr(self, "assertIsNone"):


### PR DESCRIPTION
Parsing of raw data would fail if the packet boundary happened to fall between the last byte of raw data and the SOH field separator.  Change to ensure the SOH exists, and the field doesn't complete parsing until it has been processed.  Added a check that it's actually SOH too.